### PR TITLE
Side-by-side表示に切り替えたときマージボタンが押せるバグ修正

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -30,10 +30,9 @@ function injectScriptFile(tabId, filePath) {
     chrome.tabs.sendMessage(tabId, {name: "hasGitlabClass"}, null, function(response) {
       // jsのinject
       if (response && !response.gitlabClass) {
-        chrome.tabs.executeScript(tabId, {file: filePath}, function() {
-          resolve();
-        });
+        chrome.tabs.executeScript(tabId, {file: filePath});
       }
+      resolve();
     });
   });
 }

--- a/js/contents.js
+++ b/js/contents.js
@@ -53,7 +53,8 @@ function insertConfirmScript() {
   var $form = GitLab.getMergeFormElement();
 
   if ($form.length > 0) {
-    $form.submit(function() {
+    $form.off("submit");
+    $form.on("submit", function() {
       if (!confirm("マージします。よろしいですか？")) {
         GitLab.mergeCancel();
         return false;


### PR DESCRIPTION
GitLabのバージョンによってjsを動的に挿入している箇所で、既にjs挿入済みの場合、
`Promise.resolve()` を返していないため、次のメソッドがチェーンされず、
ボタンを押すことができる状態となっていたため、常に `Promise.resolve()` を返すように修正。
また、上記修正後、マージ確認ダイアログ表示のイベントが複数回登録されるバグも修正。
